### PR TITLE
feat: Allow specification of now --public in .drone.yml

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -122,6 +122,17 @@ pipeline:
 +   scale: 2
 ```
 
+Example configuration for specifying the `--public` argument for the `now` CLI.
+
+```diff
+pipeline:
+  now:
+    image: lucap/drone-now
+    deploy_name: deployment-name
+    secrets: [ now_token ]
+-   scale: 2
++   public: true
+```
 
 # Secret Reference
 

--- a/README.md
+++ b/README.md
@@ -45,4 +45,5 @@ pipeline:
     directory: public
     alias: my.deployment.com
     secrets: [ now_token ]
+    public: true
 ```

--- a/script.sh
+++ b/script.sh
@@ -4,6 +4,15 @@ set -e
 NOW_DEPLOY_OPTIONS=" --no-clipboard"
 NOW_AUTH=""
 
+# Is this a public deployment?
+if [ "$PLUGIN_PUBLIC" == "true" ]
+then
+  echo "> adding option --public"
+  NOW_DEPLOY_OPTIONS="${NOW_DEPLOY_OPTIONS} --public"
+else
+  echo "> --public option not specified"
+fi
+
 # Get the token or error
 if [ -z "$PLUGIN_NOW_TOKEN" ]
 then

--- a/script.sh
+++ b/script.sh
@@ -7,10 +7,10 @@ NOW_AUTH=""
 # Is this a public deployment?
 if [ "$PLUGIN_PUBLIC" == "true" ]
 then
-  echo "> adding option --public"
+  echo "> adding option --public.  If you are using an OSS plan, your source and logs will be public!"
   NOW_DEPLOY_OPTIONS="${NOW_DEPLOY_OPTIONS} --public"
 else
-  echo "> --public option not specified"
+  echo "> --public option not specified."
 fi
 
 # Get the token or error


### PR DESCRIPTION
Allows users of the Drone plugin to specify the `--public` option as they would when using the `now` CLI directory.  To do this, simply add the option to the `.drone.yml` file:
```yaml
my_build_step:
  image: lucap/drone-now
  public: true
  ..other options...
```